### PR TITLE
利用者退会処理　他

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,13 @@
  *= require_tree .
  *= require_self
  */
+ @import "bootstrap";
+ @import 'font-awesome-sprockets';
+ @import 'font-awesome';
+
+.field_with_errors {
+  display: contents;
+  input {
+    border: 4px solid red;
+  }
+}

--- a/app/controllers/users/mypages_controller.rb
+++ b/app/controllers/users/mypages_controller.rb
@@ -1,20 +1,29 @@
 class Users::MypagesController < ApplicationController
   def edit
-    # 現在ログインしているuserの情報を取得
     @user = User.find(current_user.id)
   end
 
   def update
-    # 現在ログインしているuserの情報を取得
     @user = User.find(current_user.id)
-    @user.update(user_params)
-    redirect_to rooms_path
+    #　更新できたらルーム一覧ページに、NOなら利用者情報編集ページに遷移
+    if @user.update(user_params)
+      redirect_to rooms_path
+    else
+      render :edit
+    end
   end
 
   def unsubscribe
   end
 
+  #退会処理(利用者の有効フラグが退会済になる)
   def withdraw
+    user = User.find(current_user.id)
+    user.is_deleted = true
+    user.update(user_is_deleted)
+    #ログアウト状態にし、ホーム画面に戻る
+    reset_session
+    redirect_to root_path
   end
 
   private
@@ -22,5 +31,10 @@ class Users::MypagesController < ApplicationController
   # 利用者のニックネーム/メール/アイコンの変更
   def user_params
     params.require(:user).permit(:name, :email, :image)
+  end
+
+  # 利用者の有効フラグを「退会済」にする
+  def user_is_deleted
+     params.permit(:is_deleted)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,9 +51,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    edit_mypages_path(current_user)
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,7 @@
 
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
-
+  before_action :reject_user, only: [:create]
   # GET /resource/sign_in
   # def new
   #   super
@@ -19,6 +19,22 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # protected
+
+  #ログイン後ルーム一覧に遷移する処理
+  def after_sign_in_path_for(resource)
+    rooms_path
+  end
+
+  #退会した利用者がログインできないようにする処理
+  def reject_user
+    user = User.find_by(email: params[:user][:email].downcase)
+    if user
+      if (user.valid_password?(params[:user][:password]) && (user.active_for_authentication? != true))
+        flash[:notice] = "退会済です"
+        redirect_to new_user_session_path
+      end
+    end
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,16 @@ class User < ApplicationRecord
   has_many :tasks
   has_many :room_users
 
+  #refileの画像処理で必要
   attachment :image
+
+  #デフォルト値はfalse、退会処理をするとtrueに変更
+  enum is_deleted: { 有効: false, 退会済: true }
+
+  #is_deletedカラムが有効であればtrueを返す
+  def active_for_authentication?
+    super && (self.is_deleted == "有効")
+  end
 
   validates :name, presence: true, length: { minimum: 3 }
 end

--- a/app/views/users/mypages/edit.html.erb
+++ b/app/views/users/mypages/edit.html.erb
@@ -13,6 +13,8 @@
         <%= attachment_image_tag @user, :image, format: "jpeg", id: "img_prev", fallback: "no_image.jpg", size: "100x100" %><br>
         <%= f.attachment_field :image %>
     </div>
-    <%= f.submit "変更を保存" %>
+    <%= f.submit "変更を保存" ,class: "btn btn-primary" %>
 <% end %>
 
+<%= link_to "パスワードを変更する", edit_user_registration_path %>
+<%= link_to "退会する", mypages_unsubscribe_path %>

--- a/app/views/users/mypages/unsubscribe.html.erb
+++ b/app/views/users/mypages/unsubscribe.html.erb
@@ -1,2 +1,6 @@
 <h1>Users::Mypages#unsubscribe</h1>
-<p>Find me in app/views/users/mypages/unsubscribe.html.erb</p>
+本当に退会しますか？
+
+<%= link_to "マイページに戻る", edit_mypages_path %>
+
+<%= link_to "退会する", mypages_withdraw_path, method: :patch %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,43 +1,24 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2>パスワードを変更する</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
-
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.label :password %><br>
     <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation %><br />
+    <%= f.label :password_confirmation %><br>
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.label :current_password %><br>
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
-
   <div class="actions">
     <%= f.submit "Update" %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<%= link_to "マイページに戻る", edit_mypages_path(current_user.id) %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,7 @@
 <h2>ログイン</h2>
+<% if flash[:notice] %>
+  <p><%= flash[:notice] %></p>
+<% end %>
 
 <%= form_with model: @user, url: new_user_session_path, local: true do |f| %>
 


### PR DESCRIPTION
１．退会処理のコントローラ・モデル作成
２．退会したユーザーがログインできないようにする処理の追加
３．バリデーションの際にフォームの縁が赤くなるようにする
４．ログイン後の遷移先をルーム一覧画面に設定
５．サインイン後の遷移先をマイページに設定